### PR TITLE
DEN-27-contact-form-polish-POST-validation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ function App() {
 		dispatch(fetchDentists());
 		dispatch(fetchLegal());
 		dispatch(fetchFaq());
-		dispatch(computeUniqueCategories());
+		dispatch(computeUniqueCategories()); // Probably need to set this up like addContact in a way and just do in faq file
 	}, [dispatch]);
 
 	return (

--- a/src/features/contact/ContactForm.jsx
+++ b/src/features/contact/ContactForm.jsx
@@ -1,4 +1,4 @@
-import { Button, Label, Col, FormGroup } from 'reactstrap';
+import { Button, Label, Row, Col, FormGroup } from 'reactstrap';
 import { Formik, Field, Form, ErrorMessage } from 'formik';
 import * as Yup from 'yup';
 import { postContact } from './contactsSlice';
@@ -17,7 +17,7 @@ const ContactForm = () => {
 	});
 
 	const handleSubmit = (values, { setSubmitting, resetForm }) => {
-		// Handle form submission here
+		// Handle form submission here, building body for PUT
 		const contact = {
 			name: values.name,
 			email: values.email,
@@ -46,43 +46,45 @@ const ContactForm = () => {
 				validationSchema={validationSchema}
 				onSubmit={handleSubmit}
 			>
-				{({ values, touched, errors, dirty, isSubmitting, handleChange, handleBlur, handleSubmit, handleReset }) => (
+				{({ touched, errors, dirty, isSubmitting }) => (
 					<Form>
-						{dirty}
 						{/* Wrap all form elements inside a single parent <Form> element */}
-						<FormGroup row>
+						<Row>
 							<Col
 								lg='6'
-								className='mb-4 mb-lg-0'
+								className='mb-4'
 							>
 								<Field
-									className='form-control rounded-0'
+									className={`${(errors.name && touched.name) || (errors.name && dirty.name) ? 'border-danger border-1' : ''} form-control rounded-0`}
 									name='name'
 									placeholder='Your Name'
 								/>
 								<ErrorMessage
 									name='name'
-									component='p'
+									component='div'
 									className='text-danger ps-1 pt-1'
 								/>
 							</Col>
-							<Col lg='6'>
+							<Col
+								lg='6'
+								className='mb-4'
+							>
 								<Field
-									className='form-control rounded-0'
+									className={`${(errors.email && touched.email) || (errors.email && dirty.email) ? 'border-danger border-1' : ''} form-control rounded-0`}
 									name='email'
 									placeholder='Your Email'
 								/>
 								<ErrorMessage
 									name='email'
-									component='p'
+									component='div'
 									className='text-danger ps-1 pt-1'
 								/>
 							</Col>
-						</FormGroup>
-						<FormGroup row>
+						</Row>
+						<Row>
 							<Col>
 								<Field
-									className='form-control'
+									className={`${(errors.message && touched.message) || (errors.message && dirty.message) ? 'border-danger border-1' : ''} form-control rounded-0`}
 									name='message'
 									as='textarea'
 									placeholder='Your Message'
@@ -90,11 +92,11 @@ const ContactForm = () => {
 								/>
 								<ErrorMessage
 									name='message'
-									component='p'
+									component='div'
 									className='text-danger ps-1 pt-1'
 								/>
 							</Col>
-						</FormGroup>
+						</Row>
 						{/* Add other form fields here */}
 						<Button
 							color='primary'

--- a/src/features/contact/ContactForm.jsx
+++ b/src/features/contact/ContactForm.jsx
@@ -1,7 +1,38 @@
 import { Button, Label, Col, FormGroup } from 'reactstrap';
 import { Formik, Field, Form, ErrorMessage } from 'formik';
+import * as Yup from 'yup';
+import { postContact } from './contactsSlice';
+import { useDispatch } from 'react-redux';
 
 const ContactForm = () => {
+	const dispatch = useDispatch();
+
+	// Define the validation schema using Yup
+	const validationSchema = Yup.object().shape({
+		name: Yup.string()
+			.required('Name is required')
+			.matches(/^(.*[a-zA-Z]){2,}.*$/, 'Must have at least 2 letters'),
+		email: Yup.string().email('Invalid email').required('Email is required'),
+		message: Yup.string().required('Message is required'),
+	});
+
+	const handleSubmit = (values, { setSubmitting, resetForm }) => {
+		// Handle form submission here
+		const contact = {
+			name: values.name,
+			email: values.email,
+			message: values.message,
+			date: new Date(Date.now()).toISOString(),
+		};
+		try {
+			dispatch(postContact(contact));
+		} catch (error) {
+			console.log(error);
+		}
+		resetForm();
+		setSubmitting(false);
+	};
+
 	return (
 		<Col className='mt-5'>
 			<h2 className='section-heading text-dark '>Get In Touch</h2>
@@ -12,52 +43,69 @@ const ContactForm = () => {
 					email: '',
 					message: '',
 				}}
+				validationSchema={validationSchema}
+				onSubmit={handleSubmit}
 			>
-				<Form>
-					{/* Wrap all form elements inside a single parent <Form> element */}
-					<FormGroup row>
-						<Col
-							lg='6'
-							className='mb-4 mb-lg-0'
+				{({ values, touched, errors, dirty, isSubmitting, handleChange, handleBlur, handleSubmit, handleReset }) => (
+					<Form>
+						{dirty}
+						{/* Wrap all form elements inside a single parent <Form> element */}
+						<FormGroup row>
+							<Col
+								lg='6'
+								className='mb-4 mb-lg-0'
+							>
+								<Field
+									className='form-control rounded-0'
+									name='name'
+									placeholder='Your Name'
+								/>
+								<ErrorMessage
+									name='name'
+									component='p'
+									className='text-danger ps-1 pt-1'
+								/>
+							</Col>
+							<Col lg='6'>
+								<Field
+									className='form-control rounded-0'
+									name='email'
+									placeholder='Your Email'
+								/>
+								<ErrorMessage
+									name='email'
+									component='p'
+									className='text-danger ps-1 pt-1'
+								/>
+							</Col>
+						</FormGroup>
+						<FormGroup row>
+							<Col>
+								<Field
+									className='form-control'
+									name='message'
+									as='textarea'
+									placeholder='Your Message'
+									rows='5'
+								/>
+								<ErrorMessage
+									name='message'
+									component='p'
+									className='text-danger ps-1 pt-1'
+								/>
+							</Col>
+						</FormGroup>
+						{/* Add other form fields here */}
+						<Button
+							color='primary'
+							type='submit'
+							className='mt-3'
+							disabled={isSubmitting}
 						>
-							<Field
-								className='form-control rounded-0'
-								name='name'
-								placeholder='Your Name'
-							/>
-							<ErrorMessage name='name'>{(msg) => <p className='text-danger'>{msg}</p>}</ErrorMessage>
-						</Col>
-						<Col lg='6'>
-							<Field
-								className='form-control rounded-0'
-								name='email'
-								placeholder='Your Email'
-							/>
-							<ErrorMessage name='email'>{(msg) => <p className='text-danger'>{msg}</p>}</ErrorMessage>
-						</Col>
-					</FormGroup>
-					<FormGroup row>
-						<Col>
-							<Field
-								className='form-control'
-								name='feedback'
-								as='textarea'
-								placeholder='Your Message'
-								rows='5'
-							/>
-							{/* <ErrorMessage name=''>{(msg) => <p className='text-danger'>{msg}</p>}</ErrorMessage> */}
-						</Col>
-					</FormGroup>
-
-					{/* Add other form fields here */}
-					<Button
-						color='primary'
-						type='submit'
-						className='mt-3'
-					>
-						Send Message
-					</Button>
-				</Form>
+							{!isSubmitting ? 'Send Message' : 'sending...'}
+						</Button>
+					</Form>
+				)}
 			</Formik>
 		</Col>
 	);

--- a/src/features/contact/contactsSlice.jsx
+++ b/src/features/contact/contactsSlice.jsx
@@ -1,0 +1,67 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { baseUrl } from '../../shared/baseUrl';
+
+export const postContact = createAsyncThunk('contacts/postContact', async (contact, { dispatch }) => {
+	try {
+		const response = await fetch(baseUrl + 'contacts', {
+			method: 'POST',
+			body: JSON.stringify(contact),
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		});
+
+		if (!response.ok) {
+			return Promise.reject('Unable to post response, status: ' + response.status);
+		}
+
+		const data = await response.json();
+		dispatch(addContact(data)); // Dispatch the addComment action with the received data
+	} catch (error) {
+		return Promise.reject(error);
+	}
+});
+
+const initialState = {
+	contactsArray: [], // Fulfilled
+	isLoading: true, // Pending
+	errMsg: '', // Rejected
+};
+
+const contactsSlice = createSlice({
+	name: 'contacts',
+	initialState,
+	reducers: {
+		addContact: (state, action) => {
+			const newContact = {
+				id: state.contactsArray.length + 1,
+				...action.payload,
+			};
+			state.contactsArray.push(newContact);
+		},
+	},
+	extraReducers: {
+		// Not using fetch, but might set up an admin section to show contacts and have sort
+		//
+		//
+		// [fetchContacts.pending]: (state) => {
+		// 	state.isLoading = true;
+		// },
+		// [fetchContacts.fulfilled]: (state, action) => {
+		// 	state.isLoading = false;
+		// 	state.errMsg = '';
+		// 	state.contactsArray = action.payload;
+		// },
+		// [fetchContacts.rejected]: (state, action) => {
+		// 	state.isLoading = false;
+		// 	state.errMsg = action.error ? action.error.message : 'Fetch failed';
+		// },
+		[postContact.rejected]: (state, action) => {
+			state.errMsg = action.error ? action.error.message : 'Fetch failed';
+		},
+	},
+});
+
+export const contactsReducer = contactsSlice.reducer;
+
+export const { addContact } = contactsSlice.actions;

--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,7 @@ import { servicesReducer } from './features/services/servicesSlice';
 import { dentistsReducer } from './features/dentists/dentistsSlice';
 import { legalReducer } from './features/legal/legalSlice';
 import { faqReducer } from './features/faq/faqSlice';
+import { contactsReducer } from './features/contact/contactsSlice';
 
 export const store = configureStore({
 	reducer: {
@@ -11,6 +12,7 @@ export const store = configureStore({
 		dentists: dentistsReducer,
 		legal: legalReducer,
 		faq: faqReducer,
+		contacts: contactsReducer,
 	},
 	middleware: [...getDefaultMiddleware(), logger],
 });


### PR DESCRIPTION
now including error border styles and polished messaging with yup.  Had serveral successful POSTs.  Will want error, loading and successful banner or message displayed instead of form. Still didnt see the disabled submit button.  Might be due to local setup and everything so instantaneous.  Perhaps I need to change 2 sec delay to more on json-server. Could also be a lack of understanding on my part with Formik props and form handling.  Probably the later ;)